### PR TITLE
rails 5.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 gemfile:
   - gemfiles/virtual_attributes_50.gemfile
-#  - gemfiles/virtual_attributes_51.gemfile
+  - gemfiles/virtual_attributes_51.gemfile
 #  - gemfiles/virtual_attributes_52.gemfile
 
 

--- a/Appraisals
+++ b/Appraisals
@@ -3,14 +3,16 @@
   appraise "#{db_gem}-#{ar_version.split('.').first(2).join}" do
     gem "activerecord", "~> #{ar_version}"
 
-    if ar_version >= "5.1"
-      gem "pg"
+    gem "pg"
+    if ar_version >= "5.0"
       gem "mysql2"
+    else
+      gem "mysql2", '~> 0.4.0'
+    end
+    if ar_version >= "5.2"
       gem "sqlite3"
     else
       gem "sqlite3", "~> 1.3.6"
-      gem "pg", " ~> 0.18.4"
-      gem "mysql2", '~> 0.4.0'
     end
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6"
-gem "pg", " ~> 0.18.4"
+gem "pg"
 gem "mysql2", '~> 0.4.0'
 
 gemspec

--- a/gemfiles/virtual_attributes_50.gemfile
+++ b/gemfiles/virtual_attributes_50.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.7"
 gem "sqlite3", "~> 1.3.6"
-gem "pg", " ~> 0.18.4"
-gem "mysql2", "~> 0.4.0"
+gem "pg"
+gem "mysql2"
 
 gemspec path: "../"

--- a/gemfiles/virtual_attributes_51.gemfile
+++ b/gemfiles/virtual_attributes_51.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.6"
-gem "sqlite3"
+gem "sqlite3", "~> 1.3.6"
 gem "pg"
 gem "mysql2"
 

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -148,7 +148,11 @@ module ActiveRecord
             if to_ref.macro == :has_one || to_ref.macro == :belongs_to
               blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
               lambda do |t|
-                join_keys = to_ref.join_keys(to_ref.klass)
+                if ActiveRecord.version.to_s >= "5.1"
+                  join_keys = to_ref.join_keys
+                else
+                  join_keys = to_ref.join_keys(to_ref.klass)
+                end
                 src_model_id = arel_attribute(join_keys.foreign_key, t)
                 VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)
               end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -176,7 +176,7 @@ module ActiveRecord
       end
     end
 
-    include Module.new {
+    include(Module.new {
       # From ActiveRecord::FinderMethods
       def find_with_associations
         real = without_virtual_includes
@@ -221,6 +221,6 @@ module ActiveRecord
 
         real.calculate(operation, attribute_name)
       end
-    }
+    })
   end
 end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -86,7 +86,7 @@ module ActiveRecord
     # rubocop:disable Style/BlockDelimiters, Layout/SpaceAfterComma, Style/HashSyntax
     # rubocop:disable Layout/AlignHash, Metrics/AbcSize, Metrics/MethodLength
     class JoinDependency
-      def instantiate(result_set, aliases)
+      def instantiate(result_set, *_, &block)
         primary_key = aliases.column_alias(join_root, join_root.primary_key)
 
         seen = Hash.new { |i, object_id|
@@ -154,7 +154,7 @@ module ActiveRecord
         message_bus.instrument('instantiation.active_record', payload) do
           result_set.each { |row_hash|
             parent_key = primary_key ? row_hash[primary_key] : row_hash
-            parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases)
+            parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases, &block)
             construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
           }
         end
@@ -182,9 +182,17 @@ module ActiveRecord
         real = without_virtual_includes
         return super if real.equal?(self)
 
-        recs = real.find_with_associations
+        if ActiveRecord.version.to_s >= "5.1"
+          recs, join_dep = real.find_with_associations { |relation, join_dependency| [relation, join_dependency] }
+        else
+          recs = real.find_with_associations
+        end
         MiqPreloader.preload(recs, preload_values + includes_values) if includes_values
 
+        # when 5.0 support is dropped, assume a block given
+        if block_given?
+          yield recs, join_dep
+        end
         recs
       end
 

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -110,7 +110,11 @@ module VirtualAttributes
 
           foreign_table = reflection.klass.arel_table
           # need db access for the keys, so delaying all this lookup until call time
-          join_keys = reflection.join_keys(reflection.klass)
+          if ActiveRecord.version.to_s >= "5.1"
+            join_keys = reflection.join_keys
+          else
+            join_keys = reflection.join_keys(reflection.klass)
+          end
           query       = query.where(t[join_keys.foreign_key].eq(foreign_table[join_keys.key]))
 
           arel_column = if method_name == :size


### PR DESCRIPTION
Move our rails 5.1 `virtual_attribute` changes from manageiq to here.

NOTE:

tested:
- `join_keys` change
- `aliases` => `_`

untested:
- `&block`
- `find_with_associations`

see also https://github.com/ManageIQ/manageiq/pull/18076