### PR TITLE
rename to activerecord_virtual_attributes

### DIFF
--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -4,18 +4,18 @@ $LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require "active_record/virtual_attributes/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "active_record-virtual_attributes"
+  spec.name          = "activerecord-virtual_attributes"
   spec.version       = ActiveRecord::VirtualAttributes::VERSION
   spec.authors       = ["Keenan Brock"]
   spec.email         = ["keenan@thebrocks.net"]
 
   spec.summary       = %q{Access non-sql attributes from sql}
   spec.description   = %q{Define attributes in arel}
-  spec.homepage      = "https://github.com/kbrock/active_record-virtual_attributes"
+  spec.homepage      = "https://github.com/ManageIQ/activerecord-virtual_attributes"
   spec.license       = "Apache 2.0"
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/kbrock/active_record-virtual_attributes"
-  spec.metadata["changelog_uri"] = "https://github.com/kbrock/active_record-virtual_attributes/blob/master/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/ManageIQ/activerecord-virtual_attributes"
+  spec.metadata["changelog_uri"] = "https://github.com/ManageIQ/activerecord-virtual_attributes/blob/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/lib/activerecord-virtual_attributes.rb
+++ b/lib/activerecord-virtual_attributes.rb
@@ -1,0 +1,1 @@
+require "active_record/virtual_attributes"


### PR DESCRIPTION
removing the underscore for consistency
with rails AR gem convention

prepping to rename repo over to `activerecord-virtual_attributes`